### PR TITLE
Change ibrowse URL

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 {cover_enabled, true}.
 {erl_opts, [fail_on_warning, debug_info]}.
-{deps, [{ibrowse, ".*", {git, "git://github.com/andrewtj/ibrowse.git", "master"}}]}.
+{deps, [{ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", "master"}}]}.


### PR DESCRIPTION
Upstream now builds with rebar so there's no need to use my ibrowse fork anymore.

— Andrew
